### PR TITLE
fix: Assign path to args

### DIFF
--- a/internal/args/args.go
+++ b/internal/args/args.go
@@ -35,7 +35,8 @@ func SetArgs(rawArgs []string) (a BpArgs, err error) {
 		return BpArgs{}, err
 	}
 
-	if rawArgs[3] == "" {
+	a.PackPath = rawArgs[3]
+	if a.PackPath == "" {
 		err := errors.New("no path provided")
 		return BpArgs{}, err
 	}

--- a/internal/packer/packer.go
+++ b/internal/packer/packer.go
@@ -13,7 +13,8 @@ import (
 func PackerProcess(a args.BpArgs) error {
 	err := os.MkdirAll(a.PackPath, os.ModePerm)
 	if err != nil {
-		err = errors.New("failed to create directory")
+		mkdirErr := errors.New("directory invalid")
+		err = errors.Join(mkdirErr, err)
 		return err
 	}
 


### PR DESCRIPTION
Path argument was left unassigned, causing program to fail.